### PR TITLE
Replace deprecated view handler with twig rendering

### DIFF
--- a/src/Controller/Action/AddGiftCardToOrderAction.php
+++ b/src/Controller/Action/AddGiftCardToOrderAction.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Setono\SyliusGiftCardPlugin\Controller\Action;
 
-use FOS\RestBundle\View\View;
-use FOS\RestBundle\View\ViewHandlerInterface;
 use Setono\SyliusGiftCardPlugin\Applicator\GiftCardApplicatorInterface;
 use Setono\SyliusGiftCardPlugin\Form\Type\AddGiftCardToOrderType;
 use Setono\SyliusGiftCardPlugin\Model\OrderInterface;
@@ -17,11 +15,12 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Twig\Environment;
 use Webmozart\Assert\Assert;
 
 final class AddGiftCardToOrderAction
 {
-    private ViewHandlerInterface $viewHandler;
+    private Environment $twig;
 
     private FormFactoryInterface $formFactory;
 
@@ -34,14 +33,14 @@ final class AddGiftCardToOrderAction
     private RedirectUrlResolverInterface $redirectRouteResolver;
 
     public function __construct(
-        ViewHandlerInterface $viewHandler,
+        Environment $twig,
         FormFactoryInterface $formFactory,
         CartContextInterface $cartContext,
         FlashBagInterface $flashBag,
         GiftCardApplicatorInterface $giftCardApplicator,
         RedirectUrlResolverInterface $redirectRouteResolver
     ) {
-        $this->viewHandler = $viewHandler;
+        $this->twig = $twig;
         $this->formFactory = $formFactory;
         $this->cartContext = $cartContext;
         $this->flashBag = $flashBag;
@@ -72,14 +71,6 @@ final class AddGiftCardToOrderAction
             return new RedirectResponse($this->redirectRouteResolver->getUrlToRedirectTo($request, 'sylius_shop_cart_summary'));
         }
 
-        $view = View::create()
-            ->setData([
-                // Apparently we have to pass the form, and not the createdView
-                'form' => $form,
-            ])
-            ->setTemplate('@SetonoSyliusGiftCardPlugin/Shop/addGiftCardToOrder.html.twig')
-        ;
-
-        return $this->viewHandler->handle($view);
+        return (new Response())->setContent($this->twig->render('@SetonoSyliusGiftCardPlugin/Shop/addGiftCardToOrder.html.twig', ['form' => $form->createView()]));
     }
 }

--- a/src/Controller/Action/GiftCardBalanceAction.php
+++ b/src/Controller/Action/GiftCardBalanceAction.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace Setono\SyliusGiftCardPlugin\Controller\Action;
 
-use FOS\RestBundle\View\View;
-use FOS\RestBundle\View\ViewHandlerInterface;
 use Setono\SyliusGiftCardPlugin\Model\GiftCardBalanceCollection;
 use Setono\SyliusGiftCardPlugin\Repository\GiftCardRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Twig\Environment;
 
 /**
  * The purpose of this class is to show the gift card balance, i.e. what amount is still available on enabled gift cards
@@ -18,14 +17,14 @@ final class GiftCardBalanceAction
 {
     private GiftCardRepositoryInterface $giftCardRepository;
 
-    private ViewHandlerInterface $viewHandler;
+    private Environment $twig;
 
     public function __construct(
         GiftCardRepositoryInterface $giftCardRepository,
-        ViewHandlerInterface $viewHandler
+        Environment $twig
     ) {
         $this->giftCardRepository = $giftCardRepository;
-        $this->viewHandler = $viewHandler;
+        $this->twig = $twig;
     }
 
     public function __invoke(Request $request): Response
@@ -34,14 +33,6 @@ final class GiftCardBalanceAction
             $this->giftCardRepository->findEnabled()
         );
 
-        $view = View::create();
-        $view
-            ->setTemplate('@SetonoSyliusGiftCardPlugin/Admin/giftCardBalance.html.twig')
-            ->setData([
-                'giftCardBalanceCollection' => $giftCardBalanceCollection,
-            ])
-        ;
-
-        return $this->viewHandler->handle($view);
+        return (new Response())->setContent($this->twig->render('@SetonoSyliusGiftCardPlugin/Admin/giftCardBalance.html.twig', ['giftCardBalanceCollection' => $giftCardBalanceCollection]));
     }
 }

--- a/src/Controller/Action/SearchGiftCardAction.php
+++ b/src/Controller/Action/SearchGiftCardAction.php
@@ -4,24 +4,23 @@ declare(strict_types=1);
 
 namespace Setono\SyliusGiftCardPlugin\Controller\Action;
 
-use FOS\RestBundle\View\View;
-use FOS\RestBundle\View\ViewHandlerInterface;
 use Setono\SyliusGiftCardPlugin\Form\Type\GiftCardSearchType;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Twig\Environment;
 
 final class SearchGiftCardAction
 {
-    private ViewHandlerInterface $viewHandler;
+    private Environment $twig;
 
     private FormFactoryInterface $formFactory;
 
     public function __construct(
-        ViewHandlerInterface $viewHandler,
+        Environment $twig,
         FormFactoryInterface $formFactory
     ) {
-        $this->viewHandler = $viewHandler;
+        $this->twig = $twig;
         $this->formFactory = $formFactory;
     }
 
@@ -31,15 +30,6 @@ final class SearchGiftCardAction
         $form = $this->formFactory->create(GiftCardSearchType::class, $searchGiftCardCommand);
         $form->handleRequest($request);
 
-        $view = View::create();
-        $view
-            ->setTemplate('@SetonoSyliusGiftCardPlugin/Shop/GiftCard/search.html.twig')
-            ->setData([
-                'form' => $form->createView(),
-                'giftCard' => ($form->isSubmitted() && $form->isValid()) ? $searchGiftCardCommand->getGiftCard() : null,
-            ])
-        ;
-
-        return $this->viewHandler->handle($view);
+        return (new Response())->setContent($this->twig->render('@SetonoSyliusGiftCardPlugin/Shop/GiftCard/search.html.twig', ['form' => $form->createView(), 'giftCard' => ($form->isSubmitted() && $form->isValid()) ? $searchGiftCardCommand->getGiftCard() : null]));
     }
 }

--- a/src/Resources/config/services/controller.xml
+++ b/src/Resources/config/services/controller.xml
@@ -9,7 +9,7 @@
 
         <service id="setono_sylius_gift_card.controller.action.add_gift_card_to_order"
                  class="Setono\SyliusGiftCardPlugin\Controller\Action\AddGiftCardToOrderAction">
-            <argument type="service" id="fos_rest.view_handler.default"/>
+            <argument type="service" id="twig"/>
             <argument type="service" id="form.factory"/>
             <argument type="service" id="sylius.context.cart"/>
             <argument type="service" id="session.flash_bag"/>
@@ -28,12 +28,12 @@
         <service id="setono_sylius_gift_card.controller.action.gift_card_balance"
                  class="Setono\SyliusGiftCardPlugin\Controller\Action\GiftCardBalanceAction">
             <argument type="service" id="setono_sylius_gift_card.repository.gift_card"/>
-            <argument type="service" id="fos_rest.view_handler.default"/>
+            <argument type="service" id="twig"/>
         </service>
 
         <service id="setono_sylius_gift_card.controller.action.search_gift_card"
                  class="Setono\SyliusGiftCardPlugin\Controller\Action\SearchGiftCardAction">
-            <argument type="service" id="fos_rest.view_handler.default"/>
+            <argument type="service" id="twig"/>
             <argument type="service" id="form.factory"/>
         </service>
 


### PR DESCRIPTION
HI!
As reported in the [FOSRestBundle/UPGRADING-3.0.md](https://github.com/FriendsOfSymfony/FOSRestBundle/blob/3.x/UPGRADING-3.0.md) the method setTemplate has been removed from the View/View class.
To resolve the issue this PR will replace the unnecessary `fos_rest.view_handler.default` service with the `twig` service.