### PR TITLE
Adjust template reference

### DIFF
--- a/src/Resources/config/routes/admin.yaml
+++ b/src/Resources/config/routes/admin.yaml
@@ -3,7 +3,7 @@ setono_sylius_gift_card_admin_gift_card:
         alias: setono_sylius_gift_card.gift_card
         section: admin
         only: [index, update, delete, bulkDelete]
-        templates: '@SyliusAdmin/Crud'
+        templates: '@SyliusAdmin\\Crud'
         redirect: index
         grid: setono_sylius_gift_card_admin_gift_card
         vars:
@@ -40,7 +40,7 @@ setono_sylius_gift_card_admin_gift_card_configuration:
         alias: setono_sylius_gift_card.gift_card_configuration
         section: admin
         only: [index, create, update, delete, bulkDelete]
-        templates: '@SyliusAdmin/Crud'
+        templates: '@SyliusAdmin\\Crud'
         redirect: index
         grid: setono_sylius_gift_card_admin_gift_card_configuration
         vars:


### PR DESCRIPTION
As shown [here](https://docs.sylius.com/en/1.8/cookbook/entities/custom-model.html#define-routing-for-entity-administration) Sylius use the double backslash to refer to the template in the controller. This also solves a problem using Symfony 5.2.