### PR TITLE
Use Entity Manager Interface instead of Object Manager

### DIFF
--- a/spec/Applicator/GiftCardApplicatorSpec.php
+++ b/spec/Applicator/GiftCardApplicatorSpec.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace spec\Setono\SyliusGiftCardPlugin\Applicator;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\EntityManagerInterface;
 use PhpSpec\ObjectBehavior;
 use Setono\SyliusGiftCardPlugin\Applicator\GiftCardApplicator;
 use Setono\SyliusGiftCardPlugin\Applicator\GiftCardApplicatorInterface;
@@ -19,7 +19,7 @@ final class GiftCardApplicatorSpec extends ObjectBehavior
     public function let(
         GiftCardRepositoryInterface $giftCardRepository,
         OrderProcessorInterface $orderProcessor,
-        ObjectManager $orderManager
+        EntityManagerInterface $orderManager
     ): void {
         $this->beConstructedWith($giftCardRepository, $orderProcessor, $orderManager);
     }
@@ -37,7 +37,7 @@ final class GiftCardApplicatorSpec extends ObjectBehavior
     public function it_applies(
         GiftCardRepositoryInterface $giftCardRepository,
         OrderProcessorInterface $orderProcessor,
-        ObjectManager $orderManager,
+        EntityManagerInterface $orderManager,
         OrderInterface $order,
         GiftCardInterface $giftCard,
         ChannelInterface $channel

--- a/spec/Modifier/OrderGiftCardAmountModifierSpec.php
+++ b/spec/Modifier/OrderGiftCardAmountModifierSpec.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace spec\Setono\SyliusGiftCardPlugin\Modifier;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\EntityManagerInterface;
 use PhpSpec\ObjectBehavior;
 use Setono\SyliusGiftCardPlugin\Model\AdjustmentInterface;
 use Setono\SyliusGiftCardPlugin\Model\GiftCardInterface;
@@ -16,7 +16,7 @@ use Setono\SyliusGiftCardPlugin\Modifier\OrderGiftCardAmountModifierInterface;
 final class OrderGiftCardAmountModifierSpec extends ObjectBehavior
 {
     public function let(
-        ObjectManager $giftCardManager
+        EntityManagerInterface $giftCardManager
     ): void {
         $this->beConstructedWith($giftCardManager);
     }

--- a/src/Applicator/GiftCardApplicator.php
+++ b/src/Applicator/GiftCardApplicator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Setono\SyliusGiftCardPlugin\Applicator;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\EntityManagerInterface;
 use RuntimeException;
 use Setono\SyliusGiftCardPlugin\Exception\ChannelMismatchException;
 use Setono\SyliusGiftCardPlugin\Exception\GiftCardNotFoundException;
@@ -21,13 +21,13 @@ final class GiftCardApplicator implements GiftCardApplicatorInterface
     /** @var OrderProcessorInterface */
     private $orderProcessor;
 
-    /** @var ObjectManager */
+    /** @var EntityManagerInterface */
     private $orderManager;
 
     public function __construct(
         GiftCardRepositoryInterface $giftCardRepository,
         OrderProcessorInterface $orderProcessor,
-        ObjectManager $orderManager
+        EntityManagerInterface $orderManager
     ) {
         $this->giftCardRepository = $giftCardRepository;
         $this->orderProcessor = $orderProcessor;

--- a/src/Modifier/OrderGiftCardAmountModifier.php
+++ b/src/Modifier/OrderGiftCardAmountModifier.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Setono\SyliusGiftCardPlugin\Modifier;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\EntityManagerInterface;
 use RuntimeException;
 use function Safe\sprintf;
 use Setono\SyliusGiftCardPlugin\Model\AdjustmentInterface;
@@ -16,10 +16,10 @@ use Setono\SyliusGiftCardPlugin\Model\OrderInterface;
  */
 final class OrderGiftCardAmountModifier implements OrderGiftCardAmountModifierInterface
 {
-    /** @var ObjectManager */
+    /** @var EntityManagerInterface */
     private $giftCardManager;
 
-    public function __construct(ObjectManager $giftCardManager)
+    public function __construct(EntityManagerInterface $giftCardManager)
     {
         $this->giftCardManager = $giftCardManager;
     }


### PR DESCRIPTION
Hello! Using the combination of Sylius 1.9, Symfony 5.2 and Doctrine 2 there is some error generated by the incompatibility between the sylius.manager.order service and the ObjectManager class. Using EntityManagerInterface to define the property will solve the problem.