### PR TITLE
Move the flush of order outside the applicator

### DIFF
--- a/src/Applicator/GiftCardApplicator.php
+++ b/src/Applicator/GiftCardApplicator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Setono\SyliusGiftCardPlugin\Applicator;
 
-use Doctrine\Persistence\ObjectManager;
 use RuntimeException;
 use Setono\SyliusGiftCardPlugin\Exception\ChannelMismatchException;
 use Setono\SyliusGiftCardPlugin\Exception\GiftCardNotFoundException;
@@ -19,16 +18,12 @@ final class GiftCardApplicator implements GiftCardApplicatorInterface
 
     private OrderProcessorInterface $orderProcessor;
 
-    private ObjectManager $orderManager;
-
     public function __construct(
         GiftCardRepositoryInterface $giftCardRepository,
-        OrderProcessorInterface $orderProcessor,
-        ObjectManager $orderManager
+        OrderProcessorInterface $orderProcessor
     ) {
         $this->giftCardRepository = $giftCardRepository;
         $this->orderProcessor = $orderProcessor;
-        $this->orderManager = $orderManager;
     }
 
     /**
@@ -65,8 +60,6 @@ final class GiftCardApplicator implements GiftCardApplicatorInterface
         $order->addGiftCard($giftCard);
 
         $this->orderProcessor->process($order);
-
-        $this->orderManager->flush();
     }
 
     /**
@@ -81,8 +74,6 @@ final class GiftCardApplicator implements GiftCardApplicatorInterface
         $order->removeGiftCard($giftCard);
 
         $this->orderProcessor->process($order);
-
-        $this->orderManager->flush();
     }
 
     private function getGiftCard(string $giftCardCode): GiftCardInterface

--- a/src/Controller/Action/AddGiftCardToOrderAction.php
+++ b/src/Controller/Action/AddGiftCardToOrderAction.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Setono\SyliusGiftCardPlugin\Controller\Action;
 
+use Doctrine\Persistence\ManagerRegistry;
+use Setono\DoctrineObjectManagerTrait\ORM\ORMManagerTrait;
 use Setono\SyliusGiftCardPlugin\Applicator\GiftCardApplicatorInterface;
 use Setono\SyliusGiftCardPlugin\Form\Type\AddGiftCardToOrderType;
 use Setono\SyliusGiftCardPlugin\Model\OrderInterface;
@@ -20,6 +22,8 @@ use Webmozart\Assert\Assert;
 
 final class AddGiftCardToOrderAction
 {
+    use ORMManagerTrait;
+
     private FormFactoryInterface $formFactory;
 
     private CartContextInterface $cartContext;
@@ -35,13 +39,15 @@ final class AddGiftCardToOrderAction
         CartContextInterface $cartContext,
         GiftCardApplicatorInterface $giftCardApplicator,
         RedirectUrlResolverInterface $redirectRouteResolver,
-        Environment $twig
+        Environment $twig,
+        ManagerRegistry $managerRegistry
     ) {
         $this->formFactory = $formFactory;
         $this->cartContext = $cartContext;
         $this->giftCardApplicator = $giftCardApplicator;
         $this->redirectRouteResolver = $redirectRouteResolver;
         $this->twig = $twig;
+        $this->managerRegistry = $managerRegistry;
     }
 
     public function __invoke(Request $request): Response
@@ -61,6 +67,8 @@ final class AddGiftCardToOrderAction
             $giftCard = $addGiftCardToOrderCommand->getGiftCard();
             Assert::notNull($giftCard);
             $this->giftCardApplicator->apply($order, $giftCard);
+
+            $this->getManager($order)->flush();
 
             $session = $request->getSession();
             if ($session instanceof Session) {

--- a/src/Controller/Action/RemoveGiftCardFromOrderAction.php
+++ b/src/Controller/Action/RemoveGiftCardFromOrderAction.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Setono\SyliusGiftCardPlugin\Controller\Action;
 
+use Doctrine\Persistence\ManagerRegistry;
+use Setono\DoctrineObjectManagerTrait\ORM\ORMManagerTrait;
 use Setono\SyliusGiftCardPlugin\Applicator\GiftCardApplicatorInterface;
 use Setono\SyliusGiftCardPlugin\Model\GiftCardInterface;
 use Setono\SyliusGiftCardPlugin\Model\OrderInterface;
@@ -17,6 +19,8 @@ use Webmozart\Assert\Assert;
 
 final class RemoveGiftCardFromOrderAction
 {
+    use ORMManagerTrait;
+
     private CartContextInterface $cartContext;
 
     private GiftCardApplicatorInterface $giftCardApplicator;
@@ -26,11 +30,13 @@ final class RemoveGiftCardFromOrderAction
     public function __construct(
         CartContextInterface $cartContext,
         GiftCardApplicatorInterface $giftCardApplicator,
-        RedirectUrlResolverInterface $redirectRouteResolver
+        RedirectUrlResolverInterface $redirectRouteResolver,
+        ManagerRegistry $managerRegistry
     ) {
         $this->cartContext = $cartContext;
         $this->giftCardApplicator = $giftCardApplicator;
         $this->redirectRouteResolver = $redirectRouteResolver;
+        $this->managerRegistry = $managerRegistry;
     }
 
     public function __invoke(Request $request): Response
@@ -43,6 +49,8 @@ final class RemoveGiftCardFromOrderAction
         $giftCard = $request->attributes->get('giftCard');
 
         $this->giftCardApplicator->remove($order, $giftCard);
+
+        $this->getManager($order)->flush();
 
         $session = $request->getSession();
         if ($session instanceof Session) {

--- a/src/Resources/config/services/applicator.xml
+++ b/src/Resources/config/services/applicator.xml
@@ -3,15 +3,11 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
     <services>
         <service id="setono_sylius_gift_card.applicator.gift_card"
                  class="Setono\SyliusGiftCardPlugin\Applicator\GiftCardApplicator">
-            <argument type="service" id="setono_sylius_gift_card.repository.gift_card" />
-            <argument type="service" id="sylius.order_processing.order_processor.composite" />
-            <argument type="service" id="sylius.manager.order" />
+            <argument type="service" id="setono_sylius_gift_card.repository.gift_card"/>
+            <argument type="service" id="sylius.order_processing.order_processor.composite"/>
         </service>
-
     </services>
-
 </container>

--- a/src/Resources/config/services/controller.xml
+++ b/src/Resources/config/services/controller.xml
@@ -14,6 +14,7 @@
             <argument type="service" id="setono_sylius_gift_card.applicator.gift_card"/>
             <argument type="service" id="setono_sylius_gift_card.resolver.redirect_url"/>
             <argument type="service" id="twig"/>
+            <argument type="service" id="doctrine"/>
         </service>
 
         <service id="setono_sylius_gift_card.controller.action.remove_gift_card_from_order"
@@ -21,6 +22,7 @@
             <argument type="service" id="sylius.context.cart"/>
             <argument type="service" id="setono_sylius_gift_card.applicator.gift_card"/>
             <argument type="service" id="setono_sylius_gift_card.resolver.redirect_url"/>
+            <argument type="service" id="doctrine"/>
         </service>
 
         <service id="setono_sylius_gift_card.controller.action.gift_card_balance"


### PR DESCRIPTION
Move the flush of order outside the applicator because flushes are handled by Doctrine middleware for Symfony messages