### PR TITLE
Fix compatibility type for Symfony 6.x

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -43,7 +43,7 @@ final class Configuration implements ConfigurationInterface
                     ->info('The length of the generated gift card code')
                     ->min(1)
                     ->max(255)
-                    ->example(16)
+                    ->example('16')
         ;
 
         $this->addResourcesSection($rootNode);

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -43,7 +43,6 @@ final class Configuration implements ConfigurationInterface
                     ->info('The length of the generated gift card code')
                     ->min(1)
                     ->max(255)
-                    ->example('16')
         ;
 
         $this->addResourcesSection($rootNode);


### PR DESCRIPTION
It is expecting array|string