### PR TITLE
Fix admin urls

### DIFF
--- a/src/Resources/config/routes/admin.yaml
+++ b/src/Resources/config/routes/admin.yaml
@@ -65,7 +65,7 @@ setono_sylius_gift_card_admin_gift_card_create_for_channel:
     path: /gift-cards/create
     methods: [GET]
     defaults:
-        _controller: sylius.controller.channel:indexAction
+        _controller: sylius.controller.channel::indexAction
         _sylius:
             repository:
                 method: findAll
@@ -76,7 +76,7 @@ setono_sylius_gift_card_admin_gift_card_create:
     path: /gift-cards/create/{channelCode}
     methods: [GET, POST]
     defaults:
-        _controller: setono_sylius_gift_card.controller.gift_card:createAction
+        _controller: setono_sylius_gift_card.controller.gift_card::createAction
         _sylius:
             factory:
                 method: createForChannel
@@ -99,7 +99,7 @@ setono_sylius_gift_card_admin_gift_card_orders_index:
     path: /gift-cards/{id}/orders
     methods: [GET, POST]
     defaults:
-        _controller: sylius.controller.order:indexAction
+        _controller: sylius.controller.order::indexAction
         _sylius:
             vars:
                 route:

--- a/src/Resources/config/routes/admin_ajax.yaml
+++ b/src/Resources/config/routes/admin_ajax.yaml
@@ -2,7 +2,7 @@ setono_sylius_gift_card_admin_ajax_customer_by_email_phrase:
     path: /customer/search
     methods: [GET]
     defaults:
-        _controller: sylius.controller.customer:indexAction
+        _controller: sylius.controller.customer::indexAction
         _format: json
         _sylius:
             serialization_groups: [Default]
@@ -16,7 +16,7 @@ setono_sylius_gift_card_admin_ajax_customer_by_email:
     path: /customer/email
     methods: [GET]
     defaults:
-        _controller: sylius.controller.customer:indexAction
+        _controller: sylius.controller.customer::indexAction
         _format: json
         _sylius:
             serialization_groups: [Default]


### PR DESCRIPTION
Tested on Sylius 1.12 / PHP 8.2

In the admin, when clicking on "gift cards", I have the error:
```
An exception has been thrown during the rendering of a template ("The controller for URI "/admin/gift-cards/create" is not callable: Controller "sylius.controller.channel:indexAction" does neither exist as service nor as class.").
```
