### PR TITLE
Fix removed class on Sylis API 1.11

### DIFF
--- a/src/Resources/config/api_resources/Order.xml
+++ b/src/Resources/config/api_resources/Order.xml
@@ -100,7 +100,7 @@
                 <attribute name="method">PATCH</attribute>
                 <attribute name="path">/shop/orders/{tokenValue}/address</attribute>
                 <attribute name="messenger">input</attribute>
-                <attribute name="input">Sylius\Bundle\ApiBundle\Command\Checkout\AddressOrder</attribute>
+                <attribute name="input">Sylius\Bundle\ApiBundle\Command\Checkout\UpdateCart</attribute>
                 <attribute name="denormalization_context">
                     <attribute name="groups">shop:cart:address</attribute>
                 </attribute>
@@ -330,7 +330,7 @@
                 <attribute name="method">PATCH</attribute>
                 <attribute name="path">/shop/orders/{tokenValue}/apply-coupon</attribute>
                 <attribute name="messenger">input</attribute>
-                <attribute name="input">Sylius\Bundle\ApiBundle\Command\Cart\ApplyCouponToCart</attribute>
+                <attribute name="input">Sylius\Bundle\ApiBundle\Command\Checkout\UpdateCart</attribute>
                 <attribute name="denormalization_context">
                     <attribute name="groups">shop:cart:apply_coupon</attribute>
                 </attribute>


### PR DESCRIPTION
See https://github.com/Sylius/Sylius/blob/1.13/UPGRADE-API-1.11.md#:~:text=Sylius%5CBundle%5CApiBundle%5CCommand%5CCart%5CApplyCouponToCart%20and%20Sylius%5CBundle%5CApiBundle%5CCommand%5CCheckout%5CAddressOrder%20commands%20have%20been%20replaced%20with%20Sylius%5CBundle%5CApiBundle%5CCommand%5CCheckout%5CUpdateCart.