### PR TITLE
Map the entity traits with PHP 8 attributes as well as annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,20 @@ setono_sylius_gift_card:
 
 ### Apply the traits/interfaces to your entities
 
-Apply the plugin traits to your `Product`, `Order`, `OrderItem` and `OrderItemUnit` entities:
+Apply the plugin traits to your `Product`, `Order`, `OrderItem` and `OrderItemUnit` entities. The traits carry their
+Doctrine mapping as PHP 8 attributes *and* as annotations, so they work whether your application maps its entities
+with `type: attribute` (the Sylius-Standard default in `config/packages/doctrine.yaml`) or `type: annotation`. The
+samples below are attribute-mapped:
 
 ```php
 // src/Entity/Product/Product.php
+use Doctrine\ORM\Mapping as ORM;
 use Setono\SyliusGiftCardPlugin\Model\ProductInterface as SetonoSyliusGiftCardProductInterface;
 use Setono\SyliusGiftCardPlugin\Model\ProductTrait as SetonoSyliusGiftCardProductTrait;
+use Sylius\Component\Core\Model\Product as BaseProduct;
 
+#[ORM\Entity]
+#[ORM\Table(name: 'sylius_product')]
 class Product extends BaseProduct implements SetonoSyliusGiftCardProductInterface
 {
     use SetonoSyliusGiftCardProductTrait;
@@ -102,9 +109,13 @@ class Product extends BaseProduct implements SetonoSyliusGiftCardProductInterfac
 
 ```php
 // src/Entity/Order/Order.php
+use Doctrine\ORM\Mapping as ORM;
 use Setono\SyliusGiftCardPlugin\Model\OrderInterface as SetonoSyliusGiftCardOrderInterface;
 use Setono\SyliusGiftCardPlugin\Model\OrderTrait as SetonoSyliusGiftCardOrderTrait;
+use Sylius\Component\Core\Model\Order as BaseOrder;
 
+#[ORM\Entity]
+#[ORM\Table(name: 'sylius_order')]
 class Order extends BaseOrder implements SetonoSyliusGiftCardOrderInterface
 {
     use SetonoSyliusGiftCardOrderTrait {
@@ -121,8 +132,12 @@ class Order extends BaseOrder implements SetonoSyliusGiftCardOrderInterface
 
 ```php
 // src/Entity/Order/OrderItem.php
+use Doctrine\ORM\Mapping as ORM;
 use Setono\SyliusGiftCardPlugin\Model\OrderItemTrait as SetonoSyliusGiftCardOrderItemTrait;
+use Sylius\Component\Core\Model\OrderItem as BaseOrderItem;
 
+#[ORM\Entity]
+#[ORM\Table(name: 'sylius_order_item')]
 class OrderItem extends BaseOrderItem
 {
     use SetonoSyliusGiftCardOrderItemTrait;
@@ -131,16 +146,20 @@ class OrderItem extends BaseOrderItem
 
 ```php
 // src/Entity/Order/OrderItemUnit.php
+use Doctrine\ORM\Mapping as ORM;
 use Setono\SyliusGiftCardPlugin\Model\OrderItemUnitInterface as SetonoSyliusGiftCardOrderItemUnitInterface;
 use Setono\SyliusGiftCardPlugin\Model\OrderItemUnitTrait as SetonoSyliusGiftCardOrderItemUnitTrait;
+use Sylius\Component\Core\Model\OrderItemUnit as BaseOrderItemUnit;
 
+#[ORM\Entity]
+#[ORM\Table(name: 'sylius_order_item_unit')]
 class OrderItemUnit extends BaseOrderItemUnit implements SetonoSyliusGiftCardOrderItemUnitInterface
 {
     use SetonoSyliusGiftCardOrderItemUnitTrait;
 }
 ```
 
-Register the entity overrides in `config/packages/_sylius.yaml` (see `tests/Application` for a complete working example).
+Register the entity overrides in `config/packages/_sylius.yaml` (see `tests/Application` for a complete, attribute-mapped working example).
 
 ### Update the database
 

--- a/src/Model/OrderItemUnitTrait.php
+++ b/src/Model/OrderItemUnitTrait.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
 trait OrderItemUnitTrait
 {
     /** @ORM\OneToOne(targetEntity="Setono\SyliusGiftCardPlugin\Model\GiftCardInterface", mappedBy="orderItemUnit") */
+    #[ORM\OneToOne(targetEntity: GiftCardInterface::class, mappedBy: 'orderItemUnit')]
     protected ?GiftCardInterface $giftCard = null;
 
     public function getGiftCard(): ?GiftCardInterface

--- a/src/Model/OrderTrait.php
+++ b/src/Model/OrderTrait.php
@@ -25,6 +25,10 @@ trait OrderTrait
      *     inverseJoinColumns={@ORM\JoinColumn(name="gift_card_id", referencedColumnName="id", onDelete="CASCADE")}
      * )
      */
+    #[ORM\ManyToMany(targetEntity: GiftCardInterface::class, inversedBy: 'appliedOrders')]
+    #[ORM\JoinTable(name: 'setono_sylius_gift_card__order_gift_cards')]
+    #[ORM\JoinColumn(name: 'order_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    #[ORM\InverseJoinColumn(name: 'gift_card_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     protected Collection $giftCards;
 
     public function __construct()

--- a/src/Model/ProductTrait.php
+++ b/src/Model/ProductTrait.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
 trait ProductTrait
 {
     /** @ORM\Column(type="boolean", options={"default": false}) */
+    #[ORM\Column(type: 'boolean', options: ['default' => false])]
     protected bool $giftCard = false;
 
     public function isGiftCard(): bool

--- a/tests/Application/Model/Order.php
+++ b/tests/Application/Model/Order.php
@@ -9,11 +9,8 @@ use Setono\SyliusGiftCardPlugin\Model\OrderInterface as SetonoSyliusGiftCardOrde
 use Setono\SyliusGiftCardPlugin\Model\OrderTrait as SetonoSyliusGiftCardOrderTrait;
 use Sylius\Component\Core\Model\Order as BaseOrder;
 
-/**
- * @ORM\Entity
- *
- * @ORM\Table(name="sylius_order")
- */
+#[ORM\Entity]
+#[ORM\Table(name: 'sylius_order')]
 class Order extends BaseOrder implements SetonoSyliusGiftCardOrderInterface
 {
     use SetonoSyliusGiftCardOrderTrait {

--- a/tests/Application/Model/OrderItem.php
+++ b/tests/Application/Model/OrderItem.php
@@ -10,12 +10,10 @@ use Setono\SyliusGiftCardPlugin\Model\ProductInterface;
 use Sylius\Component\Core\Model\OrderItem as BaseOrderItem;
 
 /**
- * @ORM\Entity
- *
- * @ORM\Table(name="sylius_order_item")
- *
  * @method ProductInterface|null getProduct()
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'sylius_order_item')]
 class OrderItem extends BaseOrderItem
 {
     use OrderItemTrait;

--- a/tests/Application/Model/OrderItemUnit.php
+++ b/tests/Application/Model/OrderItemUnit.php
@@ -9,11 +9,8 @@ use Setono\SyliusGiftCardPlugin\Model\OrderItemUnitInterface as SetonoSyliusGift
 use Setono\SyliusGiftCardPlugin\Model\OrderItemUnitTrait as SetonoSyliusGiftCardOrderItemUnitTrait;
 use Sylius\Component\Core\Model\OrderItemUnit as BaseOrderItemUnit;
 
-/**
- * @ORM\Entity
- *
- * @ORM\Table(name="sylius_order_item_unit")
- */
+#[ORM\Entity]
+#[ORM\Table(name: 'sylius_order_item_unit')]
 class OrderItemUnit extends BaseOrderItemUnit implements SetonoSyliusGiftCardOrderItemUnitInterface
 {
     use SetonoSyliusGiftCardOrderItemUnitTrait;

--- a/tests/Application/Model/Product.php
+++ b/tests/Application/Model/Product.php
@@ -9,11 +9,8 @@ use Setono\SyliusGiftCardPlugin\Model\ProductInterface as SetonoSyliusGiftCardPr
 use Setono\SyliusGiftCardPlugin\Model\ProductTrait as SetonoSyliusGiftCardProductTrait;
 use Sylius\Component\Core\Model\Product as BaseProduct;
 
-/**
- * @ORM\Entity
- *
- * @ORM\Table(name="sylius_product")
- */
+#[ORM\Entity]
+#[ORM\Table(name: 'sylius_product')]
 class Product extends BaseProduct implements SetonoSyliusGiftCardProductInterface
 {
     use SetonoSyliusGiftCardProductTrait;

--- a/tests/Application/config/packages/doctrine.yaml
+++ b/tests/Application/config/packages/doctrine.yaml
@@ -23,7 +23,7 @@ doctrine:
         mappings:
             App:
                 is_bundle: false
-                type: annotation
+                type: attribute
                 dir: '%kernel.project_dir%/Model'
                 prefix: 'Setono\SyliusGiftCardPlugin\Tests\Application\Model'
                 alias: App


### PR DESCRIPTION
## Summary

Sylius-Standard maps its `App` entities with Doctrine's attribute driver (`type: attribute`), which ignores docblock annotations. The plugin's `ProductTrait`, `OrderTrait` and `OrderItemUnitTrait` carried their mapping as annotations only, so on a stock host `Product.giftCard`, `Order.giftCards` and `OrderItemUnit.giftCard` were never mapped and `doctrine:schema:validate` failed on the inverse sides the plugin's own `GiftCard.orm.xml` refers to. The traits now carry both syntaxes side by side; each driver ignores the other's, so annotation-mapped hosts keep working. The test application switches to the attribute driver so CI's `doctrine:schema:validate` and the functional suite prove the path a real host takes, and the README entity samples show attribute-mapped entities.

Fixes #280

## Changes

- `src/Model/ProductTrait.php`: `#[ORM\Column(type: 'boolean', options: ['default' => false])]` next to the existing annotation.
- `src/Model/OrderTrait.php`: `#[ORM\ManyToMany]`, `#[ORM\JoinTable]`, `#[ORM\JoinColumn]` and `#[ORM\InverseJoinColumn]` as top-level attributes (doctrine/orm ^2.14 does not accept nested join-column attributes), mirroring the annotation join table `setono_sylius_gift_card__order_gift_cards` with `ON DELETE CASCADE` on both sides.
- `src/Model/OrderItemUnitTrait.php`: `#[ORM\OneToOne(targetEntity: GiftCardInterface::class, mappedBy: 'orderItemUnit')]`.
- `tests/Application/config/packages/doctrine.yaml`: `type: annotation` -> `type: attribute`.
- `tests/Application/Model/{Order,OrderItem,OrderItemUnit,Product}.php`: class-level `@ORM\Entity` / `@ORM\Table` docblocks converted to `#[ORM\Entity]` / `#[ORM\Table]` (the `@method` docblock on `OrderItem` stays). `grep -rn "@ORM" tests/Application` is now empty.
- `README.md`: the "Apply the traits/interfaces to your entities" samples are attribute-mapped and state that annotation mapping still works. No other README section touched (#291).
- No explicit column names were added to the trait fields; that is #286, which stacks on this branch.

## Verification

All run from the worktree against my own database (`ssgc_attribute_mapping_{test,dev}`; the local server is MariaDB 11.6.2).

- `vendor/bin/phpunit --testsuite unit` -> `OK (51 tests, 73 assertions)`
- `vendor/bin/phpunit --testsuite functional` -> `OK (15 tests, 50 assertions)`
- `composer analyse` -> `[OK] No errors`
- `composer check-style` -> `[OK] No errors found`
- `vendor/bin/rector process --dry-run` -> `[OK] Rector is done!`
- `(cd tests/Application && APP_ENV=test bin/console doctrine:schema:create && bin/console doctrine:schema:validate -vvv)` -> `[OK] The mapping files are correct.` / `[OK] The database schema is in sync with the mapping files.` (exit 0). Note: with the `.env` default `serverVersion=5.7` against MariaDB the validator additionally lists `DEFAULT NULL` platform diffs on Sylius' own tables; none of them concern plugin fields, and they vanish with `serverVersion=mariadb-11.6.2`. CI runs MySQL 8 with `serverVersion=8.0`, so it is unaffected.
- `information_schema` check on the created schema: `sylius_product.gift_card tinyint(1) NOT NULL DEFAULT 0`; `setono_sylius_gift_card__order_gift_cards(order_id, gift_card_id)` with both foreign keys `ON DELETE CASCADE`; `setono_sylius_gift_card__gift_card.order_item_unit_id` nullable.
- `(cd tests/Application && APP_ENV=test bin/console lint:container)` -> `[OK]`; `bin/console lint:yaml config/packages/doctrine.yaml` -> `[OK]`
- Regression proof: with `src/Model` stashed (traits without attributes) and the test app on the attribute driver, `doctrine:schema:validate` exits 3 with `GiftCard#orderItemUnit refers to the inverse side field ...OrderItemUnit#giftCard which does not exist` and `GiftCard#appliedOrders refers to the owning side field ...Order#giftCards which does not exist`, the exact failure from the issue. Passes again after unstashing.
- End to end, as the CI job does it (dev env): `doctrine:schema:validate` -> `[OK]`, `sylius:fixtures:load -n`, `assets:install`, `symfony serve -d --port=8103 --no-tls`, `(cd tests/Playwright && PLAYWRIGHT_BASE_URL=http://127.0.0.1:8103 npx playwright test)` -> `26 passed (1.3m)`.
- Not run: a fresh Sylius-Standard 1.14 install with `doctrine:migrations:diff`. The test application on the attribute driver stands in for it; the schema elements listed above are what that diff would produce.

## Notes for reviewers

- On each property the docblock comes first and the attribute second. Both must stay until annotation support is dropped, since each driver only reads its own syntax.
- `targetEntity` in the attributes uses `GiftCardInterface::class` (the traits share its namespace), which resolves to the same FQCN as the annotation strings.
- `tests/Application/config/packages/validator.yaml` still has `enable_annotations: true`; that is the validator component, not Doctrine, and out of scope here.
- Touches the same trait files as #286 (explicit column names), which is meant to stack on this branch; the README section is shared with #291.
